### PR TITLE
fix: adding a control on destroyClient method

### DIFF
--- a/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
@@ -96,7 +96,9 @@ public class BleClientManager extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void destroyClient() {
-        bleAdapter.destroyClient();
+       if(bleAdapter != null){
+            bleAdapter.destroyClient();
+        }
         bleAdapter = null;
     }
 


### PR DESCRIPTION
Adding a control on the existence of the bleAdapter before destroying it on Android this fix solves this issue [#824](https://github.com/Polidea/react-native-ble-plx/issues/824#issue-818354704) for android devices