### PR TITLE
set min sdk version to 21 for react native 0.64.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you
 buildscript {
     ext {
         ...
-        minSdkVersion = 18
+        minSdkVersion = 21
         ...
 ```
 4. In `build.gradle` make sure to add jitpack repository to known repositories:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ android {
     buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion safeExtGet('targetSdkVersion', 27)
     }
     lintOptions {

--- a/docs/README_V1.md
+++ b/docs/README_V1.md
@@ -120,7 +120,7 @@ Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you
 android {
     ...
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         ...
 ```
 4. In `build.gradle` of `app` module make sure to add jitpack repository to known repositories:
@@ -148,7 +148,7 @@ allprojects {
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 
     <uses-sdk
-        android:minSdkVersion="18"
+        android:minSdkVersion="21"
         ...
 ```
 


### PR DESCRIPTION
Hi,
 
React Native 0.64 need a minimum version of 21 for the android Sdk.
This is a breaking change so I guess major version should be upgraded

Regards,
Nicolas