### PR TITLE
Fix iOSErrorCode type in d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -328,7 +328,7 @@ declare module 'react-native-ble-plx' {
     /**
      * iOS specific error code (if not an ATT error).
      */
-    iosErrorCode: BleATTErrorCode | null
+    iosErrorCode: BleIOSErrorCode | null
     /**
      * Android specific error code (if not an ATT error).
      */


### PR DESCRIPTION
**Purpose**
Fix `iosErrorCode` type.
Change it from `BleATTErrorCode` to `BleIOSErrorCode`.

Implementation seems to use `BleIOSErrorCode`.
See implementation at https://github.com/Polidea/react-native-ble-plx/blob/1c3ceca0166a810286d035ec782586924310f966/src/BleError.js#L36