### PR TITLE
#ownership-transfer Various updates of Polidea ownership information to dotintent

### DIFF
--- a/.github/ISSUE_TEMPLATE/project_setup.md
+++ b/.github/ISSUE_TEMPLATE/project_setup.md
@@ -29,7 +29,7 @@ Please provide detailed steps for reproducing the issue.
 
 ### Context
 
-Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions. Both JS and platform logs can be enabled via [setLogLevel](https://polidea.github.io/react-native-ble-plx/#blemanagersetloglevel) function call. 
+Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions. Both JS and platform logs can be enabled via [setLogLevel](https://dotintent.github.io/react-native-ble-plx/#blemanagersetloglevel) function call. 
 
 * Library version: X.Y.Z
 * Platform: Android/iOS.

--- a/INTRO.md
+++ b/INTRO.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/Polidea/react-native-ble-plx"><img alt="react-native-ble-plx" src="logo.png" /></a>
+  <a href="https://github.com/dotintent/react-native-ble-plx"><img alt="react-native-ble-plx" src="logo.png" /></a>
 </p>
 
 This guide is an introduction to BLE stack and APIs exported by this library. All examples

--- a/LICENSE
+++ b/LICENSE
@@ -187,6 +187,7 @@
       identification within third-party archives.
 
    Copyright 2016 Polidea
+   Copyright 2021 intent sp. z o.o.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ for the old instructions or [migration guide](./docs/MIGRATION_V1.md).
 Interested in React Native project involving Bluetooth Low Energy? [We can help you!](https://www.withintent.com/)
 
 
-[Documentation can be found here](https://polidea.github.io/react-native-ble-plx/).
+[Documentation can be found here](https://dotintent.github.io/react-native-ble-plx/).
 
 [Quick introduction can be found here](https://github.com/dotintent/react-native-ble-plx/blob/master/INTRO.md)
 
-Contact us at [Polidea](https://www.polidea.com/project/?utm_source=Github&utm_medium=Npaid&utm_campaign=Kontakt&utm_term=Code&utm_content=GH_NOP_KKT_COD_RNB001).
+Contact us at [Intent](https://withintent.com/project/?utm_source=Github&utm_medium=Npaid&utm_campaign=Kontakt&utm_term=Code&utm_content=GH_NOP_KKT_COD_RNB001).
 
 Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you have any questions, feedback or want to help!
 
@@ -128,5 +128,5 @@ Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you
 Add this to your `app/proguard-rules.pro`
 
 ```
--dontwarn com.polidea.reactnativeble.**
+-dontwarn com.withintent.reactnativeble.**
 ```

--- a/README.md
+++ b/README.md
@@ -9,26 +9,26 @@
 
 ## About this library
 
-This is React Native Bluetooth Low Energy library wrapping [Multiplatform Ble Adapter](https://github.com/Polidea/MultiPlatformBleAdapter/).
+This is React Native Bluetooth Low Energy library wrapping [Multiplatform Ble Adapter](https://github.com/dotintent/MultiPlatformBleAdapter/).
 
 It supports:
 
-- [observing device's Bluetooth adapter state](https://github.com/Polidea/react-native-ble-plx/wiki/Bluetooth-Adapter-State)
-- [scanning BLE devices](https://github.com/Polidea/react-native-ble-plx/wiki/Bluetooth-Scanning)
-- [making connections to peripherals](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Connecting)
-- [discovering services/characteristics](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Service-Discovery)
-- [reading](https://github.com/Polidea/react-native-ble-plx/wiki/Characteristic-Reading)/[writing](https://github.com/Polidea/react-native-ble-plx/wiki/Characteristic-Writing) characteristics
-- [observing characteristic notifications/indications](https://github.com/Polidea/react-native-ble-plx/wiki/Characteristic-Notifying)
-- [reading RSSI](https://github.com/Polidea/react-native-ble-plx/wiki/RSSI-Reading)
-- [negotiating MTU](https://github.com/Polidea/react-native-ble-plx/wiki/MTU-Negotiation)
-- [background mode on iOS](https://github.com/Polidea/react-native-ble-plx/wiki/Background-mode-(iOS))
+- [observing device's Bluetooth adapter state](https://github.com/dotintent/react-native-ble-plx/wiki/Bluetooth-Adapter-State)
+- [scanning BLE devices](https://github.com/dotintent/react-native-ble-plx/wiki/Bluetooth-Scanning)
+- [making connections to peripherals](https://github.com/dotintent/react-native-ble-plx/wiki/Device-Connecting)
+- [discovering services/characteristics](https://github.com/dotintent/react-native-ble-plx/wiki/Device-Service-Discovery)
+- [reading](https://github.com/dotintent/react-native-ble-plx/wiki/Characteristic-Reading)/[writing](https://github.com/dotintent/react-native-ble-plx/wiki/Characteristic-Writing) characteristics
+- [observing characteristic notifications/indications](https://github.com/dotintent/react-native-ble-plx/wiki/Characteristic-Notifying)
+- [reading RSSI](https://github.com/dotintent/react-native-ble-plx/wiki/RSSI-Reading)
+- [negotiating MTU](https://github.com/dotintent/react-native-ble-plx/wiki/MTU-Negotiation)
+- [background mode on iOS](https://github.com/dotintent/react-native-ble-plx/wiki/Background-mode-(iOS))
 - turning the device's Bluetooth adapter on
 
 It does NOT support:
 
 - bluetooth classic devices.
 - communicating between phones using BLE (Peripheral support)
-- [bonding peripherals](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Bonding)
+- [bonding peripherals](https://github.com/dotintent/react-native-ble-plx/wiki/Device-Bonding)
 
 ## Compatibility
 
@@ -54,15 +54,12 @@ for the old instructions or [migration guide](./docs/MIGRATION_V1.md).
 
 ## Documentation & Support
 
-Interested in React Native project involving Bluetooth Low Energy? [We can help you!](https://www.polidea.com/react-native)
+Interested in React Native project involving Bluetooth Low Energy? [We can help you!](https://www.withintent.com/)
 
-[Learn more about Polidea's React Native services](https://www.polidea.com/services/react-native/?utm_source=Github&utm_medium=Npaid&utm_campaign=Tech_RN&utm_term=Code&utm_content=GH_NOP_RN_COD_RNB001).
-
-[Learn more about Polidea's BLE services](https://www.polidea.com/services/ble/?utm_source=Github&utm_medium=Npaid&utm_campaign=Tech_BLE&utm_term=Code&utm_content=GH_NOP_BLE_COD_RNB001).
 
 [Documentation can be found here](https://polidea.github.io/react-native-ble-plx/).
 
-[Quick introduction can be found here](https://github.com/Polidea/react-native-ble-plx/blob/master/INTRO.md)
+[Quick introduction can be found here](https://github.com/dotintent/react-native-ble-plx/blob/master/INTRO.md)
 
 Contact us at [Polidea](https://www.polidea.com/project/?utm_source=Github&utm_medium=Npaid&utm_campaign=Kontakt&utm_term=Code&utm_content=GH_NOP_KKT_COD_RNB001).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,8 +17,8 @@
 ## 2. Publishing
 
 1. You can test pre-release changes in your chosen application by installing the library as
-  ```"react-native-ble-plx": "Polidea/react-native-ble-plx"```.
+  ```"react-native-ble-plx": "dotintent/react-native-ble-plx"```.
 2. Clean repository and publish new version: `git clean -xfd && npm publish`.
 3. Add tag to the repository in form of `x.x.x`.
-4. Add release notes to the [Github](https://github.com/Polidea/react-native-ble-plx/releases) by copying a list of changes from `CHANGELOG.md`.
+4. Add release notes to the [Github](https://github.com/dotintent/react-native-ble-plx/releases) by copying a list of changes from `CHANGELOG.md`.
 3. Check any issues which are fixed by a new version, close them and point to a new release in the comment section.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.polidea.reactnativeble">
+          package="com.withintent.reactnativeble">
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 </manifest>

--- a/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble;
+package com.withintent.reactnativeble;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -25,14 +25,14 @@ import com.polidea.multiplatformbleadapter.RefreshGattMoment;
 import com.polidea.multiplatformbleadapter.ScanResult;
 import com.polidea.multiplatformbleadapter.Service;
 import com.polidea.multiplatformbleadapter.errors.BleError;
-import com.polidea.reactnativeble.converter.BleErrorToJsObjectConverter;
-import com.polidea.reactnativeble.converter.CharacteristicToJsObjectConverter;
-import com.polidea.reactnativeble.converter.DescriptorToJsObjectConverter;
-import com.polidea.reactnativeble.converter.DeviceToJsObjectConverter;
-import com.polidea.reactnativeble.converter.ScanResultToJsObjectConverter;
-import com.polidea.reactnativeble.converter.ServiceToJsObjectConverter;
-import com.polidea.reactnativeble.utils.ReadableArrayConverter;
-import com.polidea.reactnativeble.utils.SafePromise;
+import com.withintent.reactnativeble.converter.BleErrorToJsObjectConverter;
+import com.withintent.reactnativeble.converter.CharacteristicToJsObjectConverter;
+import com.withintent.reactnativeble.converter.DescriptorToJsObjectConverter;
+import com.withintent.reactnativeble.converter.DeviceToJsObjectConverter;
+import com.withintent.reactnativeble.converter.ScanResultToJsObjectConverter;
+import com.withintent.reactnativeble.converter.ServiceToJsObjectConverter;
+import com.withintent.reactnativeble.utils.ReadableArrayConverter;
+import com.withintent.reactnativeble.utils.SafePromise;
 
 import java.util.HashMap;
 import java.util.List;

--- a/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BlePackage.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble;
+package com.withintent.reactnativeble;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;

--- a/android/src/main/java/com/polidea/reactnativeble/Event.java
+++ b/android/src/main/java/com/polidea/reactnativeble/Event.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble;
+package com.withintent.reactnativeble;
 
 public enum Event {
 

--- a/android/src/main/java/com/polidea/reactnativeble/converter/BleErrorToJsObjectConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/converter/BleErrorToJsObjectConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.converter;
+package com.withintent.reactnativeble.converter;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;

--- a/android/src/main/java/com/polidea/reactnativeble/converter/CharacteristicToJsObjectConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/converter/CharacteristicToJsObjectConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.converter;
+package com.withintent.reactnativeble.converter;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/com/polidea/reactnativeble/converter/DescriptorToJsObjectConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/converter/DescriptorToJsObjectConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.converter;
+package com.withintent.reactnativeble.converter;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/com/polidea/reactnativeble/converter/DeviceToJsObjectConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/converter/DeviceToJsObjectConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.converter;
+package com.withintent.reactnativeble.converter;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/com/polidea/reactnativeble/converter/JSObjectConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/converter/JSObjectConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.converter;
+package com.withintent.reactnativeble.converter;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableArray;

--- a/android/src/main/java/com/polidea/reactnativeble/converter/ScanResultToJsObjectConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/converter/ScanResultToJsObjectConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.converter;
+package com.withintent.reactnativeble.converter;
 
 import androidx.annotation.NonNull;
 

--- a/android/src/main/java/com/polidea/reactnativeble/converter/ServiceToJsObjectConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/converter/ServiceToJsObjectConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.converter;
+package com.withintent.reactnativeble.converter;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/com/polidea/reactnativeble/utils/Base64Converter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/utils/Base64Converter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.utils;
+package com.withintent.reactnativeble.utils;
 
 import android.util.Base64;
 

--- a/android/src/main/java/com/polidea/reactnativeble/utils/ReadableArrayConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/utils/ReadableArrayConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.utils;
+package com.withintent.reactnativeble.utils;
 
 import com.facebook.react.bridge.ReadableArray;
 

--- a/android/src/main/java/com/polidea/reactnativeble/utils/SafePromise.java
+++ b/android/src/main/java/com/polidea/reactnativeble/utils/SafePromise.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.utils;
+package com.withintent.reactnativeble.utils;
 
 import com.facebook.react.bridge.Promise;
 

--- a/android/src/main/java/com/polidea/reactnativeble/utils/UUIDConverter.java
+++ b/android/src/main/java/com/polidea/reactnativeble/utils/UUIDConverter.java
@@ -1,4 +1,4 @@
-package com.polidea.reactnativeble.utils;
+package com.withintent.reactnativeble.utils;
 
 import com.facebook.react.bridge.ReadableArray;
 

--- a/docs/README_V1.md
+++ b/docs/README_V1.md
@@ -13,7 +13,7 @@ This is React Native Bluetooth Low Energy library using [RxBluetoothKit](https:/
 
 It supports:
 
-- [observing device's Bluetooth adapter state](https://github.com/Polidea/react-native-ble-plx/wiki/Bluetooth-Adapter-State)
+- [observing device's Bluetooth adapter state](https://github.com/dotintent/react-native-ble-plx/wiki/Bluetooth-Adapter-State)
 - [scanning BLE devices](https://github.com/Polidea/react-native-ble-plx/wiki/Bluetooth-Scanning)
 - [making connections to peripherals](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Connecting)
 - [discovering services/characteristics](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Service-Discovery)

--- a/docs/README_V1.md
+++ b/docs/README_V1.md
@@ -9,25 +9,25 @@
 
 ## About this library
 
-This is React Native Bluetooth Low Energy library using [RxBluetoothKit](https://github.com/Polidea/RxBluetoothKit) and [RxAndroidBle](https://github.com/Polidea/RxAndroidBle) under the hood.
+This is React Native Bluetooth Low Energy library using [RxBluetoothKit](https://github.com/dotintent/RxBluetoothKit) and [RxAndroidBle](https://github.com/dotintent/RxAndroidBle) under the hood.
 
 It supports:
 
 - [observing device's Bluetooth adapter state](https://github.com/dotintent/react-native-ble-plx/wiki/Bluetooth-Adapter-State)
-- [scanning BLE devices](https://github.com/Polidea/react-native-ble-plx/wiki/Bluetooth-Scanning)
-- [making connections to peripherals](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Connecting)
-- [discovering services/characteristics](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Service-Discovery)
-- [reading](https://github.com/Polidea/react-native-ble-plx/wiki/Characteristic-Reading)/[writing](https://github.com/Polidea/react-native-ble-plx/wiki/Characteristic-Writing) characteristics
-- [observing characteristic notifications/indications](https://github.com/Polidea/react-native-ble-plx/wiki/Characteristic-Notifying)
-- [reading RSSI](https://github.com/Polidea/react-native-ble-plx/wiki/RSSI-Reading)
-- [negotiating MTU](https://github.com/Polidea/react-native-ble-plx/wiki/MTU-Negotiation)
-- [background mode on iOS](https://github.com/Polidea/react-native-ble-plx/wiki/Background-mode-(iOS))
+- [scanning BLE devices](https://github.com/dotintent/react-native-ble-plx/wiki/Bluetooth-Scanning)
+- [making connections to peripherals](https://github.com/dotintent/react-native-ble-plx/wiki/Device-Connecting)
+- [discovering services/characteristics](https://github.com/dotintent/react-native-ble-plx/wiki/Device-Service-Discovery)
+- [reading](https://github.com/dotintent/react-native-ble-plx/wiki/Characteristic-Reading)/[writing](https://github.com/dotintent/react-native-ble-plx/wiki/Characteristic-Writing) characteristics
+- [observing characteristic notifications/indications](https://github.com/dotintent/react-native-ble-plx/wiki/Characteristic-Notifying)
+- [reading RSSI](https://github.com/dotintent/react-native-ble-plx/wiki/RSSI-Reading)
+- [negotiating MTU](https://github.com/dotintent/react-native-ble-plx/wiki/MTU-Negotiation)
+- [background mode on iOS](https://github.com/dotintent/react-native-ble-plx/wiki/Background-mode-(iOS))
 - turning the device's Bluetooth adapter on
 
 What this library does NOT support:
 
 - communicating between phones using BLE (Peripheral support)
-- [bonding peripherals](https://github.com/Polidea/react-native-ble-plx/wiki/Device-Bonding)
+- [bonding peripherals](https://github.com/dotintent/react-native-ble-plx/wiki/Device-Bonding)
 
 ## Compatibility
 
@@ -59,13 +59,13 @@ What this library does NOT support:
 
 Interested in React Native project involving Bluetooth Low Energy? [We can help you!](https://www.polidea.com/react-native)
 
-[Learn more about Polidea's React Native services](https://www.polidea.com/services/react-native/?utm_source=Github&utm_medium=Npaid&utm_campaign=Tech_RN&utm_term=Code&utm_content=GH_NOP_RN_COD_RNB001).
+[Learn more about Intent's React Native services](https://www.polidea.com/services/react-native/?utm_source=Github&utm_medium=Npaid&utm_campaign=Tech_RN&utm_term=Code&utm_content=GH_NOP_RN_COD_RNB001).
 
-[Learn more about Polidea's BLE services](https://www.polidea.com/services/ble/?utm_source=Github&utm_medium=Npaid&utm_campaign=Tech_BLE&utm_term=Code&utm_content=GH_NOP_BLE_COD_RNB001).
+[Learn more about Intent's BLE services](https://www.polidea.com/services/ble/?utm_source=Github&utm_medium=Npaid&utm_campaign=Tech_BLE&utm_term=Code&utm_content=GH_NOP_BLE_COD_RNB001).
 
 Documentation can be found [here](https://polidea.github.io/react-native-ble-plx/).
 
-Contact us at [Polidea](https://www.polidea.com/project/?utm_source=Github&utm_medium=Npaid&utm_campaign=Kontakt&utm_term=Code&utm_content=GH_NOP_KKT_COD_RNB001).
+Contact us at [Intent](https://www.polidea.com/project/?utm_source=Github&utm_medium=Npaid&utm_campaign=Kontakt&utm_term=Code&utm_content=GH_NOP_KKT_COD_RNB001).
 
 Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you have any questions, feedback or want to help!
 
@@ -169,5 +169,5 @@ allprojects {
 Add this to your `app/proguard-rules.pro`
 
 ```
--dontwarn com.polidea.reactnativeble.**
+-dontwarn com.withintent.reactnativeble.**
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -1951,7 +1951,7 @@
 
   
     <p align="center">
-  <a href="https://github.com/Polidea/react-native-ble-plx"><img alt="react-native-ble-plx" src="logo.png" /></a>
+  <a href="https://github.com/dotintent/react-native-ble-plx"><img alt="react-native-ble-plx" src="logo.png" /></a>
 </p>
 <p>This guide is an introduction to BLE stack and APIs exported by this library. All examples
 will be based on CC2541 SensorTag.</p>

--- a/integration-tests/scripts/make-project
+++ b/integration-tests/scripts/make-project
@@ -20,7 +20,7 @@ function generate-project {
     CURRENT_COMMIT=${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT}
     echo "Installing react-native-ble-plx revision $CURRENT_COMMIT"
     # Using npm here to be able to download submodules properly.
-    npm install --save https://github.com/Polidea/react-native-ble-plx#$CURRENT_COMMIT
+    npm install --save https://github.com/dotintent/react-native-ble-plx#$CURRENT_COMMIT
     # Sometimes yarn doesn't install packets locally. Be sure that everything is in place.
     npm install
     react-native link react-native-ble-plx  # and link it

--- a/ios/BleClient.h
+++ b/ios/BleClient.h
@@ -3,7 +3,7 @@
 //  BleClient
 //
 //  Created by Przemysław Lenart on 27/07/16.
-//  Copyright © 2016 Polidea. All rights reserved.
+//  Copyright © 2016 Intent. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/ios/BleClient.xcodeproj/project.pbxproj
+++ b/ios/BleClient.xcodeproj/project.pbxproj
@@ -110,7 +110,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1000;
-				ORGANIZATIONNAME = Polidea;
+				ORGANIZATIONNAME = Intent;
 				TargetAttributes = {
 					D73F06E71D48E17B00AD5963 = {
 						CreatedOnToolsVersion = 7.3;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Polidea/react-native-ble-plx.git"
+    "url": "git+https://github.com/dotintent/react-native-ble-plx.git"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -39,8 +39,7 @@
     "Bluetooth",
     "Low",
     "Energy",
-    "BLE",
-    "Polidea"
+    "BLE"
   ],
   "jest": {
     "preset": "react-native",
@@ -48,10 +47,10 @@
       "<rootDir>/integration-tests"
     ]
   },
-  "author": "Polidea",
+  "author": "Polidea, intent sp. z o.o.",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Polidea/react-native-ble-plx/issues"
+    "url": "https://github.com/dotintent/react-native-ble-plx/issues"
   },
-  "homepage": "https://github.com/Polidea/react-native-ble-plx#readme"
+  "homepage": "https://github.com/dotintent/react-native-ble-plx#readme"
 }

--- a/react-native-ble-plx.podspec
+++ b/react-native-ble-plx.podspec
@@ -8,11 +8,11 @@ Pod::Spec.new do |s|
   s.summary      = "React Native Bluetooth Low Energy library"
 
   s.authors      = { "Przemysław Lenart" => "przemek.lenart@gmail.com" }
-  s.homepage     = "https://github.com/Polidea/react-native-ble-plx#readme"
+  s.homepage     = "https://github.com/dotintent/react-native-ble-plx#readme"
   s.license      = "Apache License 2.0"
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com/Polidea/react-native-ble-plx.git" }
+  s.source       = { :git => "https://github.com/dotintent/react-native-ble-plx.git" }
   s.source_files  = "ios/**/*.{h,m}"
   s.compiler_flags = '-DMULTIPLATFORM_BLE_ADAPTER'
 


### PR DESCRIPTION
Various replaces of Polidea info to Intent. 
All places where MultiPlatformBleAdapter repo is mentioned where left intentionally as it probably needs to be synchronised with main repository of MultiPlatformBleAdapter upgrade.

Reference links in documenation needs to upgraded after sync with marketing team. 

Android package name changed to: com.polidea.reactnativeble" but probably it needs to be checked if it's not causing any issues. 