### PR TITLE
Removed warning for Event Listeners in RN 0.65

### DIFF
--- a/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
+++ b/android/src/main/java/com/polidea/reactnativeble/BleClientManager.java
@@ -925,6 +925,16 @@ public class BleClientManager extends ReactContextBaseJavaModule {
         );
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.  
+    }
+
+    @ReactMethod
+    public void removeListeners(int count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     private void sendEvent(@NonNull Event event, @Nullable Object params) {
         getReactApplicationContext()
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)


### PR DESCRIPTION
Fixes #896 

Added required methods for NativeEventListeners to not show warning in React Native 0.65+

See this PR for more detail: https://github.com/react-native-netinfo/react-native-netinfo/pull/487