### PR TITLE
Add two instructions in README to prevent Android users from running into #248 and #730

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,29 @@ Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you
 
         ...
     ```
+1. (Required in SDK >= 23) Request location permission during runtime:
+
+    ```js
+    import { React, AndroidPermissions } from 'react-native'
+    ...
+
+    class FooBar extends React.Component {
+      ...
+      requestLocationPermission = async () => {
+        const result = await PermissionsAndroid.request(
+          PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION
+        );
+
+        if (result === PermissionsAndroid.RESULTS.GRANTED) {
+          // Do something
+        } else {
+          // Denied
+          // Do something
+        }
+      }
+      ...
+    }
+    ```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you
 1. (Required in SDK >= 23) Request location permission during runtime:
 
     ```js
-    import { React, AndroidPermissions } from 'react-native'
+    import { React, PermissionsAndroid } from 'react-native'
     ...
 
     class FooBar extends React.Component {

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you
         ...
         <uses-permission android:name="android.permission.BLUETOOTH"/>
         <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+
+        <!-- Please use FINE location instead of COARSE:
+         https://github.com/dotintent/react-native-ble-plx/issues/730#issuecomment-681946908 -->
         <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
         <!-- Add this line if your application always requires BLE. More info can be found on:


### PR DESCRIPTION
## Current Behavior

Users integrating this package supporting Android SDK >= 23 might run into #730 and will run into #248.

## New behavior

Users integrating this package supporting Android SDK >= 23 have all information provided by README to get started without hiccups.

### Details

Even thought the issues (#248 & #730) are closed since instructions are given inside the issues, having the information provided in the README will prevent users from having to dig through the internet to resolve them once encountered.

### Breaking changes

None