### PR TITLE
Updated README to reflect new react-native-ble-plx support within Expo through expo-dev-clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ Contact us at [Gitter](https://gitter.im/RxBLELibraries/react-native-ble) if you
 
 ## Configuration & Installation
 
-### Expo
+### Expo SDK 43+
 
-1. A custom expo-dev-client can now be built along with config plugins to avoid the need to eject from Expo. Learn how to integrate react-native-ble-plx with Expo [here](https://expo.canny.io/feature-requests/p/bluetooth-1). (only for expo)
+1. A custom expo-dev-client can now be built along with config plugins to avoid the need to eject from Expo. Learn how to integrate react-native-ble-plx with Expo [here](https://expo.canny.io/feature-requests/p/bluetooth-1). (only for expo SDK 43+)
+
+### Legacy Expo (SDK < 43)
+
+1. Make sure your Expo project is ejected (formerly: detached). You can read how to do it [here] (https://docs.expo.dev/expokit/eject/). (only for Expo SDK < 43)
+1. Follow steps for iOS/Android.
 
 ### iOS ([example setup](https://github.com/Cierpliwy/SensorTag))
 


### PR DESCRIPTION
It is no longer necessary to eject from Expo when using react-native-ble-plx with the release of expo-dev-clients in Expo SDK 43. Information on the new method which allows for "Expo Go" client-like development can be found [here](https://expo.canny.io/feature-requests/p/bluetooth-1).

Included sections for new workflow in Expo SDK 43+ and Legacy expo eject workflow with older versions. 