### PR TITLE
build: remove jCenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,6 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
@@ -32,7 +31,6 @@ android {
 
 repositories {
     mavenLocal()
-    jcenter()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$projectDir/../../../node_modules/react-native/android"


### PR DESCRIPTION
Build was failing this morning due to `jCenter` not being available. I don't see any maven style dependencies published, so I believe this is a safe removal.