### PR TITLE
fix: Resolves #1052 - Not a valid Bluetooth Address

### DIFF
--- a/android/src/main/java/com/bleplx/adapter/BleException.java
+++ b/android/src/main/java/com/bleplx/adapter/BleException.java
@@ -1,4 +1,0 @@
-package com.bleplx.adapter;
-
-public interface BleException {
-}

--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -445,6 +445,7 @@ public class BleModule implements BleAdapter {
                     .equals(RxBleConnection.RxBleConnectionState.CONNECTED);
             onSuccessCallback.onSuccess(connected);
         } catch (Exception e) {
+            RxBleLog.e(e, "Error while checking if device is connected");
             onErrorCallback.onError(errorConverter.toError(e));
         }
     }

--- a/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
+++ b/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
@@ -84,8 +84,6 @@ export function DashboardScreen({ navigation }: DashboardScreenProps) {
         label="Connect/disconnect test"
         onPress={() => navigation.navigate('DEVICE_CONNECT_DISCONNECT_TEST_SCREEN')}
       />
-      <AppButton label="Call disconnect with wrong id" onPress={() => BLEService.isDeviceWithIdConnected('asd')} />
-      <AppButton label="Call disconnect with wrong id" onPress={() => BLEService.isDeviceWithIdConnected('asd')} />
       <FlatList
         style={{ flex: 1 }}
         data={foundDevices}

--- a/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
+++ b/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
@@ -85,6 +85,7 @@ export function DashboardScreen({ navigation }: DashboardScreenProps) {
         onPress={() => navigation.navigate('DEVICE_CONNECT_DISCONNECT_TEST_SCREEN')}
       />
       <AppButton label="Call disconnect with wrong id" onPress={() => BLEService.isDeviceWithIdConnected('asd')} />
+      <AppButton label="Call disconnect with wrong id" onPress={() => BLEService.isDeviceWithIdConnected('asd')} />
       <FlatList
         style={{ flex: 1 }}
         data={foundDevices}

--- a/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
+++ b/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
@@ -84,6 +84,7 @@ export function DashboardScreen({ navigation }: DashboardScreenProps) {
         label="Connect/disconnect test"
         onPress={() => navigation.navigate('DEVICE_CONNECT_DISCONNECT_TEST_SCREEN')}
       />
+      <AppButton label="Call disconnect with wrong id" onPress={() => BLEService.isDeviceWithIdConnected('asd')} />
       <FlatList
         style={{ flex: 1 }}
         data={foundDevices}


### PR DESCRIPTION
This was fixed already, but error was suppressed in native.
Now it's logged in logcat. 