### PR TITLE
fix: add node version variable

### DIFF
--- a/.github/actions/setup_test_project/action.yml
+++ b/.github/actions/setup_test_project/action.yml
@@ -4,6 +4,9 @@ inputs:
   REACT_NATIVE_VERSION:
     description: React Native version to use
     required: false
+  NODE_VERSION:
+    description: Node version to use # https://github.com/actions/setup-node#supported-version-syntax
+    required: false
 
 runs:
   using: composite
@@ -11,10 +14,10 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version-file: .nvmrc
+        node-version: ${{ inputs.NODE_VERSION }}
 
     - name: Initialize project template
-      run: npx react-native@latest init BlePlxExample --version ${{ inputs.REACT_NATIVE_VERSION }} --directory test_project --skip-install --verbose
+      run: npx react-native@latest init BlePlxExample --verbose --version ${{ inputs.REACT_NATIVE_VERSION }} --directory test_project --skip-install --verbose
       shell: bash
 
     - name: Cache dependencies
@@ -27,7 +30,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ inputs.REACT_NATIVE_VERSION }}-yarn-${{ hashFiles('**/yarn.lock') }}
           ${{ runner.os }}-${{ inputs.REACT_NATIVE_VERSION }}-yarn-
-    
+
     - name: Copy project files
       run: node ./scripts/copyExampleProjectFiles.js
       shell: bash

--- a/.github/actions/setup_test_project/action.yml
+++ b/.github/actions/setup_test_project/action.yml
@@ -17,7 +17,7 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
 
     - name: Initialize project template
-      run: npx react-native@latest init BlePlxExample --verbose --version ${{ inputs.REACT_NATIVE_VERSION }} --directory test_project --skip-install --verbose
+      run: npx react-native@latest init BlePlxExample --version ${{ inputs.REACT_NATIVE_VERSION }} --directory test_project --skip-install --verbose
       shell: bash
 
     - name: Cache dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,16 @@ jobs:
         run: yarn prepack
 
   build-android:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        react_native_version: ['0.72.4', ' 0.71.13', '0.70.13']
+        configurations:
+          [
+            { react_native_version: '0.72.6', node_version: 18 },
+            { react_native_version: '0.71.14', node_version: 16 },
+            { react_native_version: '0.70.13', node_version: 16 }
+          ]
     env:
       TURBO_CACHE_DIR: .turbo/android
     steps:
@@ -62,15 +67,16 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup_test_project
         with:
-          REACT_NATIVE_VERSION: ${{ matrix.react_native_version }}
+          REACT_NATIVE_VERSION: ${{ matrix.configurations.react_native_version }}
+          NODE_VERSION: ${{ matrix.configurations.node_version }}
 
       - name: Cache turborepo for Android
         uses: actions/cache@v3
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.react_native_version }}-turborepo-android-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-turborepo-android-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.react_native_version }}-turborepo-android-
+            ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-turborepo-android-
 
       - name: Check turborepo cache for Android
         run: |
@@ -99,9 +105,9 @@ jobs:
           path: |
             ~/.gradle/wrapper
             ~/.gradle/caches
-          key: ${{ runner.os }}-${{ matrix.react_native_version }}-gradle-${{ hashFiles('test_project/android/gradle/wrapper/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-gradle-${{ hashFiles('test_project/android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.react_native_version }}-gradle-
+            ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-gradle-
 
       - name: Build example for Android
         run: |
@@ -112,7 +118,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        react_native_version: ['0.72.4', ' 0.71.13', '0.70.13']
+        configurations:
+          [
+            { react_native_version: '0.72.6', node_version: 18 },
+            { react_native_version: '0.71.14', node_version: 16 },
+            { react_native_version: '0.70.13', node_version: 16 }
+          ]
     env:
       TURBO_CACHE_DIR: .turbo/ios
     steps:
@@ -122,15 +133,16 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup_test_project
         with:
-          REACT_NATIVE_VERSION: ${{ matrix.react_native_version }}
+          REACT_NATIVE_VERSION: ${{ matrix.configurations.react_native_version }}
+          NODE_VERSION: ${{ matrix.configurations.node_version }}
 
       - name: Cache turborepo for iOS
         uses: actions/cache@v3
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.react_native_version }}-turborepo-ios-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-turborepo-ios-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.react_native_version }}-turborepo-ios-
+            ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-turborepo-ios-
 
       - name: Check turborepo cache for iOS
         run: |
@@ -147,9 +159,9 @@ jobs:
         with:
           path: |
             **/ios/Pods
-          key: ${{ runner.os }}-${{ matrix.react_native_version }}-cocoapods-${{ hashFiles('test_project/ios/Podfile.lock') }}
+          key: ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-cocoapods-${{ hashFiles('test_project/ios/Podfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.react_native_version }}-cocoapods-
+            ${{ runner.os }}-${{ matrix.configurations.react_native_version }}-cocoapods-
 
       - name: Install cocoapods
         if: env.turbo_cache_hit != 1


### PR DESCRIPTION
Added node version configuration. 
Encountered [problem](https://stackoverflow.com/questions/77194683/npx-react-native-init-awesomeproject-failed-in-node-version-18-18-0-but-succeed) with `react-native init` on node 18 and ubuntu. Couldn't pinpoint real problem nor solve it, so for a temporary hotfix I have change ubuntu machine to macos.
