### PR TITLE
feat: provide option to disable legacy scan for Android

### DIFF
--- a/android/src/main/java/com/bleplx/BlePlxModule.java
+++ b/android/src/main/java/com/bleplx/BlePlxModule.java
@@ -188,6 +188,7 @@ public class BlePlxModule extends ReactContextBaseJavaModule {
 
         int scanMode = DEFAULT_SCAN_MODE_LOW_POWER;
         int callbackType = DEFAULT_CALLBACK_TYPE_ALL_MATCHES;
+        boolean legacyScan = true;
 
         if (options != null) {
             if (options.hasKey("scanMode") && options.getType("scanMode") == ReadableType.Number) {
@@ -196,11 +197,14 @@ public class BlePlxModule extends ReactContextBaseJavaModule {
             if (options.hasKey("callbackType") && options.getType("callbackType") == ReadableType.Number) {
                 callbackType = options.getInt("callbackType");
             }
+          if (options.hasKey("legacyScan") && options.getType("legacyScan") == ReadableType.Boolean) {
+            legacyScan = options.getBoolean("legacyScan");
+          }
         }
 
         bleAdapter.startDeviceScan(
                 filteredUUIDs != null ? ReadableArrayConverter.toStringArray(filteredUUIDs) : null,
-                scanMode, callbackType,
+                scanMode, callbackType, legacyScan,
                 new OnEventCallback<ScanResult>() {
                     @Override
                     public void onEvent(ScanResult data) {

--- a/android/src/main/java/com/bleplx/adapter/BleAdapter.java
+++ b/android/src/main/java/com/bleplx/adapter/BleAdapter.java
@@ -28,6 +28,7 @@ public interface BleAdapter {
             String[] filteredUUIDs,
             int scanMode,
             int callbackType,
+            boolean legacyScan,
             OnEventCallback<ScanResult> onEventCallback,
             OnErrorCallback onErrorCallback);
 

--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -1160,8 +1160,8 @@ public class BleModule implements BleAdapter {
 
     private void safeStartDeviceScan(final UUID[] uuids,
                                      final int scanMode,
-                                     int callbackType,
-                                     boolean legacyScan,
+                                     final int callbackType,
+                                     final boolean legacyScan,
                                      final OnEventCallback<ScanResult> onEventCallback,
                                      final OnErrorCallback onErrorCallback) {
         if (rxBleClient == null) {

--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -177,6 +177,7 @@ public class BleModule implements BleAdapter {
     public void startDeviceScan(String[] filteredUUIDs,
                                 int scanMode,
                                 int callbackType,
+                                boolean legacyScan,
                                 OnEventCallback<ScanResult> onEventCallback,
                                 OnErrorCallback onErrorCallback) {
         UUID[] uuids = null;
@@ -189,7 +190,7 @@ public class BleModule implements BleAdapter {
             }
         }
 
-        safeStartDeviceScan(uuids, scanMode, callbackType, onEventCallback, onErrorCallback);
+        safeStartDeviceScan(uuids, scanMode, callbackType, legacyScan, onEventCallback, onErrorCallback);
     }
 
     @Override
@@ -1160,6 +1161,7 @@ public class BleModule implements BleAdapter {
     private void safeStartDeviceScan(final UUID[] uuids,
                                      final int scanMode,
                                      int callbackType,
+                                     boolean legacyScan,
                                      final OnEventCallback<ScanResult> onEventCallback,
                                      final OnErrorCallback onErrorCallback) {
         if (rxBleClient == null) {
@@ -1170,6 +1172,7 @@ public class BleModule implements BleAdapter {
         ScanSettings scanSettings = new ScanSettings.Builder()
                 .setScanMode(scanMode)
                 .setCallbackType(callbackType)
+                .setLegacy(legacyScan)
                 .build();
 
         int length = uuids == null ? 0 : uuids.length;

--- a/example/src/components/atoms/Button/Button.styled.tsx
+++ b/example/src/components/atoms/Button/Button.styled.tsx
@@ -5,6 +5,7 @@ import { AppText } from '../AppText/AppText'
 export const Container = styled(TouchableOpacity)`
   ${({ theme }) => css`
     background-color: ${theme.colors.mainRed};
+    margin: 10px;
     padding: 12px;
     align-items: center;
     border-radius: 100px;

--- a/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
+++ b/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
@@ -77,14 +77,14 @@ export function DashboardScreen({ navigation }: DashboardScreenProps) {
         label="Look for devices"
         onPress={() => {
           setFoundDevices([])
-          BLEService.initializeBLE().then(() => BLEService.scanDevices(true, addFoundDevice))
+          BLEService.initializeBLE().then(() => BLEService.scanDevices(addFoundDevice, null, true))
         }}
       />
       <AppButton
         label="Look for devices (legacy off)"
         onPress={() => {
           setFoundDevices([])
-          BLEService.initializeBLE().then(() => BLEService.scanDevices(false, addFoundDevice))
+          BLEService.initializeBLE().then(() => BLEService.scanDevices(addFoundDevice, null, false))
         }}
       />
       <AppButton label="Ask for permissions" onPress={BLEService.requestBluetoothPermission} />

--- a/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
+++ b/example/src/screens/MainStack/DashboardScreen/DashboardScreen.tsx
@@ -75,7 +75,17 @@ export function DashboardScreen({ navigation }: DashboardScreenProps) {
       )}
       <AppButton
         label="Look for devices"
-        onPress={() => BLEService.initializeBLE().then(() => BLEService.scanDevices(addFoundDevice))}
+        onPress={() => {
+          setFoundDevices([])
+          BLEService.initializeBLE().then(() => BLEService.scanDevices(true, addFoundDevice))
+        }}
+      />
+      <AppButton
+        label="Look for devices (legacy off)"
+        onPress={() => {
+          setFoundDevices([])
+          BLEService.initializeBLE().then(() => BLEService.scanDevices(false, addFoundDevice))
+        }}
       />
       <AppButton label="Ask for permissions" onPress={BLEService.requestBluetoothPermission} />
       <AppButton label="Go to nRF test" onPress={() => navigation.navigate('DEVICE_NRF_TEST_SCREEN')} />

--- a/example/src/services/BLEService/BLEService.ts
+++ b/example/src/services/BLEService/BLEService.ts
@@ -92,7 +92,7 @@ class BLEServiceInstance {
     this.showErrorToast('Bluetooth is turned off')
   }
 
-  scanDevices = async (legacyScan: boolean, onDeviceFound: (device: Device) => void, UUIDs: UUID[] | null = null) => {
+  scanDevices = async (onDeviceFound: (device: Device) => void, UUIDs: UUID[] | null = null, legacyScan?: boolean) => {
     this.manager.startDeviceScan(UUIDs, { legacyScan }, (error, device) => {
       if (error) {
         this.onError(error)

--- a/example/src/services/BLEService/BLEService.ts
+++ b/example/src/services/BLEService/BLEService.ts
@@ -92,8 +92,8 @@ class BLEServiceInstance {
     this.showErrorToast('Bluetooth is turned off')
   }
 
-  scanDevices = async (onDeviceFound: (device: Device) => void, UUIDs: UUID[] | null = null) => {
-    this.manager.startDeviceScan(UUIDs, null, (error, device) => {
+  scanDevices = async (legacyScan: boolean, onDeviceFound: (device: Device) => void, UUIDs: UUID[] | null = null) => {
+    this.manager.startDeviceScan(UUIDs, { legacyScan }, (error, device) => {
       if (error) {
         this.onError(error)
         console.error(error.message)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -162,6 +162,11 @@ declare module 'react-native-ble-plx' {
      * Scan callback type for Bluetooth LE scan [Android only]
      */
     callbackType?: ScanCallbackType
+    /**
+     * Use legacyScan (default true) [Android only]
+     * https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean)
+     */
+    legacyScan?: boolean
   }
 
   /**


### PR DESCRIPTION
Added parameters to disable legacy scan option for Android.

According to [android documentation](https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean)) disabling legacy scan is needed to correctly support scan devices with extended advertising.

Resolves #904
