### PR TITLE
Expo plugin example shows incorrect plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The plugin provides props for extra customization. Every time you change the pro
   "expo": {
     "plugins": [
       [
-        "@config-plugins/react-native-ble-plx",
+        "react-native-ble-plx",
         {
           "isBackgroundEnabled": true,
           "modes": ["peripheral", "central"],


### PR DESCRIPTION
The example code still references the unofficial expo plugin