### PR TITLE
Update @expo/config-plugins dep to include v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/react": "17.0.21"
   },
   "dependencies": {
-    "@expo/config-plugins": "^7.2.5"
+    "@expo/config-plugins": "^7.2.5 || ^8.0.0"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
---
name: 'Update @expo/config-plugins dep'
about: 'Update @expo/config-plugins dep to allow using version 8'
title: 'Update dep'
labels: feature
---

## Prerequisites

Please answer the following questions for yourself before submitting an issue. **YOU MAY DELETE THE PREREQUISITES SECTION.**

- [x] I am working on the latest version of the library.
- [x] I tested all the changes locally both on iOS and Android devices.
- [x] I run `npm run lint` and `npm test` to verify my fix.
- [x] I added local regression tests if possible.

## Description

The @expo/config-plugins package was updated to support expo 51 and the version was bumped to 8. There were no changes to the react-native-ble-plx plugin, so it is safe to use.