### PR TITLE
fix: timeout killing working connection

### DIFF
--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -1267,7 +1267,10 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
     }
 
     if (timeout != null) {
-      connect = connect.timeout(timeout, TimeUnit.MILLISECONDS);
+      connect = connect.timeout(
+        Observable.timer(timeout, TimeUnit.MILLISECONDS),
+        item -> Observable.never()
+      );
     }
 
 


### PR DESCRIPTION
Doing a BleManager.connectToDevice with a timeout specified makes the timeout fire event though the connection is established just fine. Reason is that the timeout on Android side is applied to every emitted item when it has to be applied only to the first one. This PR fixes that. 😃 