### PR TITLE
fix: use proper context instead of activity

### DIFF
--- a/android/src/main/java/com/bleplx/BlePlxModule.java
+++ b/android/src/main/java/com/bleplx/BlePlxModule.java
@@ -1,7 +1,5 @@
 package com.bleplx;
 
-import android.app.Activity;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -52,9 +50,11 @@ import io.reactivex.plugins.RxJavaPlugins;
 @ReactModule(name = BlePlxModule.NAME)
 public class BlePlxModule extends ReactContextBaseJavaModule {
   public static final String NAME = "BlePlx";
+  private final ReactApplicationContext reactContext;
 
   public BlePlxModule(ReactApplicationContext reactContext) {
     super(reactContext);
+    this.reactContext = reactContext;
     RxJavaPlugins.setErrorHandler(throwable -> {
       if (throwable instanceof UndeliverableException) {
         RxBleLog.e("Handle all unhandled exceptions from RxJava: " + throwable.getMessage());
@@ -98,11 +98,7 @@ public class BlePlxModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void createClient(String restoreStateIdentifier) {
-    final Activity activity = getCurrentActivity();
-    if (activity == null) {
-      return;
-    }
-    bleAdapter = BleAdapterFactory.getNewAdapter(activity);
+    bleAdapter = BleAdapterFactory.getNewAdapter(reactContext);
     bleAdapter.createClient(restoreStateIdentifier,
       new OnEventCallback<String>() {
         @Override


### PR DESCRIPTION
As Samuel pointed out in this [issue](https://github.com/dotintent/react-native-ble-plx/issues/1231) the createClient currently might fail if there is no activity launched yet. This can happen especially on apps making use of Android Auto since that runs on a service only and has no activity.

This PR makes use of the reactContext that is passed when creating an instance of BlePlxModule so there should be a valid context all the time now.

@dimninik you changed that a while ago, do you remember why you came up with this solution to use the activity instead of the reactContext? https://github.com/dotintent/react-native-ble-plx/pull/1089/commits/c610878a3843147444c939ed2a1c6d6da00558c0#diff-a1a97970184ebc2e5a60c771e7f36d7679d4977f1232a0f9247a77957c707a39R87