### PR TITLE
feat: remove leftover log when emitCurrentState is true

### DIFF
--- a/src/BleManager.js
+++ b/src/BleManager.js
@@ -301,7 +301,6 @@ export class BleManager {
     if (emitCurrentState) {
       var cancelled = false
       this._callPromise(this.state()).then(currentState => {
-        console.log(currentState)
         if (!cancelled) {
           listener(currentState)
         }


### PR DESCRIPTION
This PR removes presumingly leftover debug log when `emitCurrentState` in `BleManager` is set to `true`