### PR TITLE
 Guard to avoid Service.getDeviceID()' on a null object reference (#1142) and cleanServicesAndCharacteristicsForDevice outOfBounds (#1144) crashes

### DIFF
--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -1571,7 +1571,7 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
       }
     }
     for (int key : discoveredServicesKeysToRemove) {
-      if (discoveredServices.contains(key)) {
+      if (discoveredServices.indexOfKey(key) >= 0) {
         discoveredServices.remove(key);
       }
     }
@@ -1585,7 +1585,7 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
       }
     }
     for (int key : discoveredCharacteristicsKeysToRemove) {
-      if (discoveredCharacteristics.contains(key)) {
+      if (discoveredCharacteristics.indexOfKey(key) >= 0) {
         discoveredCharacteristics.remove(key);
       }
     }
@@ -1599,7 +1599,7 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
       }
     }
     for (int key : discoveredDescriptorsKeysToRemove) {
-      if (discoveredDescriptors.contains(key)) {
+      if (discoveredDescriptors.indexOfKey(key) >= 0) {
         discoveredDescriptors.remove(key);
       }
     }

--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -1562,34 +1562,45 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
   }
 
   private void cleanServicesAndCharacteristicsForDevice(@NonNull Device device) {
-    for (int i = discoveredServices.size() - 1; i >= 0; i--) {
-      if (i < discoveredServices.size()) { // guards concurrent changes in discoveredServices while iterating to avoid #1144
-        int key = discoveredServices.keyAt(i);
-        Service service = discoveredServices.get(key);
-
-        if (service == null || service.getDeviceID().equals(device.getId())) {
-          discoveredServices.remove(key);
-        }
+    List<Integer> discoveredServicesKeysToRemove = new ArrayList<>();
+    for (int i = 0; i < discoveredServices.size(); i++) {
+      int key = discoveredServices.keyAt(i);
+      Service service = discoveredServices.get(key);
+      if (service == null || service.getDeviceID().equals(device.getId())) {
+          discoveredServicesKeysToRemove.add(key);
       }
     }
-    for (int i = discoveredCharacteristics.size() - 1; i >= 0; i--) {
-      if (i < discoveredCharacteristics.size()) {
-        int key = discoveredCharacteristics.keyAt(i);
-        Characteristic characteristic = discoveredCharacteristics.get(key);
-
-        if (characteristic == null || characteristic.getDeviceId().equals(device.getId())) {
-          discoveredCharacteristics.remove(key);
-        }
+    for (int key : discoveredServicesKeysToRemove) {
+      if (discoveredServices.contains(key)) {
+        discoveredServices.remove(key);
+      }
+    }
+    
+    List<Integer> discoveredCharacteristicsKeysToRemove = new ArrayList<>();
+    for (int i = 0; i < discoveredCharacteristics.size(); i++) {
+      int key = discoveredCharacteristics.keyAt(i);
+      Characteristic characteristic = discoveredCharacteristics.get(key);
+      if (characteristic == null || characteristic.getDeviceId().equals(device.getId())) {
+        discoveredCharacteristicsKeysToRemove.add(key);
+      }
+    }
+    for (int key : discoveredCharacteristicsKeysToRemove) {
+      if (discoveredCharacteristics.contains(key)) {
+        discoveredCharacteristics.remove(key);
       }
     }
 
-    for (int i = discoveredDescriptors.size() - 1; i >= 0; i--) {
-      if (i < discoveredDescriptors.size()) {
-        int key = discoveredDescriptors.keyAt(i);
-        Descriptor descriptor = discoveredDescriptors.get(key);
-        if (descriptor == null || descriptor.getDeviceId().equals(device.getId())) {
-          discoveredDescriptors.remove(key);
-        }
+    List<Integer> discoveredDescriptorsKeysToRemove = new ArrayList<>();
+    for (int i = 0; i < discoveredDescriptors.size(); i++) {
+      int key = discoveredDescriptors.keyAt(i);
+      Descriptor descriptor = discoveredDescriptors.get(key);
+      if (descriptor == null || descriptor.getDeviceId().equals(device.getId())) {
+        discoveredDescriptorsKeysToRemove.add(key);
+      }
+    }
+    for (int key : discoveredDescriptorsKeysToRemove) {
+      if (discoveredDescriptors.contains(key)) {
+        discoveredDescriptors.remove(key);
       }
     }
   }

--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -1563,27 +1563,33 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
 
   private void cleanServicesAndCharacteristicsForDevice(@NonNull Device device) {
     for (int i = discoveredServices.size() - 1; i >= 0; i--) {
-      int key = discoveredServices.keyAt(i);
-      Service service = discoveredServices.get(key);
+      if (i < discoveredServices.size()) { // guards concurrent changes in discoveredServices while iterating to avoid #1144
+        int key = discoveredServices.keyAt(i);
+        Service service = discoveredServices.get(key);
 
-      if (service.getDeviceID().equals(device.getId())) {
-        discoveredServices.remove(key);
+        if (service == null || service.getDeviceID().equals(device.getId())) {
+          discoveredServices.remove(key);
+        }
       }
     }
     for (int i = discoveredCharacteristics.size() - 1; i >= 0; i--) {
-      int key = discoveredCharacteristics.keyAt(i);
-      Characteristic characteristic = discoveredCharacteristics.get(key);
+      if (i < discoveredCharacteristics.size()) {
+        int key = discoveredCharacteristics.keyAt(i);
+        Characteristic characteristic = discoveredCharacteristics.get(key);
 
-      if (characteristic.getDeviceId().equals(device.getId())) {
-        discoveredCharacteristics.remove(key);
+        if (characteristic == null || characteristic.getDeviceId().equals(device.getId())) {
+          discoveredCharacteristics.remove(key);
+        }
       }
     }
 
     for (int i = discoveredDescriptors.size() - 1; i >= 0; i--) {
-      int key = discoveredDescriptors.keyAt(i);
-      Descriptor descriptor = discoveredDescriptors.get(key);
-      if (descriptor.getDeviceId().equals(device.getId())) {
-        discoveredDescriptors.remove(key);
+      if (i < discoveredDescriptors.size()) {
+        int key = discoveredDescriptors.keyAt(i);
+        Descriptor descriptor = discoveredDescriptors.get(key);
+        if (descriptor == null || descriptor.getDeviceId().equals(device.getId())) {
+          discoveredDescriptors.remove(key);
+        }
       }
     }
   }


### PR DESCRIPTION
Previously opened PR https://github.com/dotintent/react-native-ble-plx/pull/1282 was still problematic, so we changed the cleanup procedure, and after all this resolved all our crash issues!