### PR TITLE
fix(android): remove device from discovered devices cache

### DIFF
--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
+++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
@@ -211,6 +211,9 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
       scanSubscription.dispose();
       scanSubscription = null;
     }
+
+    // Clear discovered devices cache to ensure devices can be rediscovered after disconnection
+    discoveredDevices.clear();
   }
 
   @Override
@@ -1299,6 +1302,9 @@ public class BleModule extends ReactContextBaseJavaModule implements BleAdapter 
     if (device == null) {
       return;
     }
+
+    // Remove device from discovered devices cache so it can be rediscovered during scans
+    discoveredDevices.remove(rxDevice.getMacAddress());
 
     cleanServicesAndCharacteristicsForDevice(device);
     connectingDevices.removeSubscription(device.getId());


### PR DESCRIPTION
The way `discoveredDevices` is handled is quite suspect.

This PR addresses issue #1279 by removing devices from the discovered devices cache in the Android implementation when they're no longer available. This should allow devices that go out of range and then return to be properly rediscovered during subsequent scans. This is a potential fix that needs further testing in various environments to confirm it resolves the issue completely.